### PR TITLE
Add instance module

### DIFF
--- a/instance/README.md
+++ b/instance/README.md
@@ -1,0 +1,22 @@
+# Instance
+
+## Required Inputs
+ - ami_id
+ - fqdn
+ - instance_type
+ - key_name
+ - subnet_id
+ - security_group_ids
+ - assign_public_ip
+
+This is a work in progress. It's cribbed from a private terraform modules repository I maintain and the code is based on
+a private instance module. There is also a public instance module. I want to combine both of them with some conditional
+logic to provision with the appropriate method (via a bastion host or not).
+
+It is build and tested with CentOS 7. Amazon Linux should work. Ubuntu will not work without changing the default
+username.
+
+
+## TODO
+ - Implement CentOS7 region->AMI map for selection of default AMI
+ - Better handle conditional public/private provisioning

--- a/instance/input.tf
+++ b/instance/input.tf
@@ -1,0 +1,79 @@
+## Inputs
+
+# Required (no default specified, will throw plan error)
+variable "ami_id" {
+  description = "ID of the AMI to launch"
+  type = "string"
+}
+
+variable "fqdn" {
+  description = "FQDN of the new instance. Passed to hostnamectl and used as ec2 Tag"
+  type = "string"
+}
+
+variable "instance_type" {
+  description = "Instance size"
+  type = "string"
+}
+
+variable "key_name" {
+  description = "Initial SSH Key to seed instance with"
+  type = "string"
+}
+
+variable "subnet_id" {
+  description = "Subnet in which to place the new instance"
+}
+
+variable "security_group_ids" {
+  description = "List of security groups to associate with the instance"
+  type = "list"
+}
+
+variable "assign_public_ip" {
+  description = "Associate a public IP address with instance"
+  type = "string"
+}
+
+# There's a chicken and egg problem here. To make this instance we require
+# another instance with a public IP. But how do we create it?
+variable "bastion_host" {
+  description = "Bastion hostname to use for provisioning"
+}
+
+variable "bastion_user" {
+  description = "Username to use for bastion host during provisioning. Key must be in agent"
+}
+
+
+# Optional parameters (default specified, not needed when requiring module)
+variable "root_volume_size" {
+  description = "Size in GB of root volume (default 20gb)"
+  default = "20"
+}
+
+variable "ami_user" {
+  description = "Default username to use to access instance. Used for provisioning"
+  default = "ec2-user"
+}
+
+variable "placement_group" {
+  description = "Name of placement group where instance is created"
+  type = "string"
+  default = ""
+}
+
+variable "source_dest_check" {
+  description = "Enable or disable EC2 source and destination checking of packets"
+  default = "true"
+}
+
+variable "ebs_optimized" {
+  description = "EBS optimized instance"
+  default = "false"
+}
+
+variable "iam_instance_profile" {
+  description = "(Optional) The IAM Instance Profile to launch the instance with."
+  default = ""
+}

--- a/instance/input.tf
+++ b/instance/input.tf
@@ -54,7 +54,7 @@ variable "root_volume_size" {
 
 variable "ami_user" {
   description = "Default username to use to access instance. Used for provisioning"
-  default = "ec2-user"
+  default = "centos"
 }
 
 variable "placement_group" {

--- a/instance/main.tf
+++ b/instance/main.tf
@@ -1,0 +1,51 @@
+resource "aws_instance" "instance" {
+  ami = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  subnet_id = "${var.subnet_id}"
+  key_name = "${var.key_name}"
+  associate_public_ip_address = "${var.assign_public_ip}"
+  source_dest_check = "${var.source_dest_check}"
+  ebs_optimized = "${var.ebs_optimized}"
+  iam_instance_profile = "${var.iam_instance_profile}"
+
+  vpc_security_group_ids = [ "${var.security_group_ids}" ]
+
+  tags {
+    Name = "${var.fqdn}"
+  }
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "${var.root_volume_size}"
+    delete_on_termination = "true"
+  }
+
+}
+
+resource "null_resource" "provision" {
+  connection {
+    user = "${var.ami_user}"
+    timeout = "1m"
+    host = "${aws_instance.instance.private_ip}"
+    bastion_host = "${var.bastion_host}"
+    bastion_user = "${var.bastion_user}"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo hostnamectl set-hostname ${var.fqdn}"
+    ]
+  }
+
+  depends_on = [
+    "aws_instance.instance"
+  ]
+
+  triggers {
+    instance_id = "${aws_instance.instance.id}"
+    fqdn = "${var.fqdn}"
+  }
+}
+
+output "private_ip" { value = "${aws_instance.instance.private_ip}" }
+output "id" { value = "${aws_instance.instance.id}" }


### PR DESCRIPTION
This is a quick instance module for me to use in another project. It will further be expanded to handle conditional scenarios such as public/private subnet and provisioning.

For now you must already have a public instance in AWS to use as the bastion host for provisioning.